### PR TITLE
new ReasoningPart type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scrapybara"
-version = "2.2.8"
+version = "2.2.9"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/scrapybara/client.py
+++ b/src/scrapybara/client.py
@@ -1169,7 +1169,7 @@ class Scrapybara:
             assistant_msg = AssistantMessage(
                 content=(
                     ([TextPart(text=step.text)] if step.text else [])
-                    + (step.reasoning if step.reasoning else [])
+                    + (step.reasoning_parts if step.reasoning_parts else [])
                     + (step.tool_calls or [])
                 )
             )
@@ -1309,7 +1309,7 @@ class Scrapybara:
             ]
 
             # Extract reasoning from reasoning part
-            reasoning = [
+            reasoning_parts = [
                 part
                 for part in act_response.message.content
                 if isinstance(part, ReasoningPart)
@@ -1318,7 +1318,7 @@ class Scrapybara:
             # Create initial step
             step = Step(
                 text=text,
-                reasoning=reasoning if reasoning else None,
+                reasoning_parts=reasoning_parts if reasoning_parts else None,
                 tool_calls=tool_calls if tool_calls else None,
                 finish_reason=act_response.finish_reason,
                 usage=act_response.usage,
@@ -1578,7 +1578,7 @@ class AsyncScrapybara:
             assistant_msg = AssistantMessage(
                 content=(
                     ([TextPart(text=step.text)] if step.text else [])
-                    + (step.reasoning if step.reasoning else [])
+                    + (step.reasoning_parts if step.reasoning_parts else [])
                     + (step.tool_calls or [])
                 )
             )
@@ -1718,7 +1718,7 @@ class AsyncScrapybara:
             ]
 
             # Extract reasoning from reasoning part
-            reasoning = [
+            reasoning_parts = [
                 part
                 for part in act_response.message.content
                 if isinstance(part, ReasoningPart)
@@ -1727,7 +1727,7 @@ class AsyncScrapybara:
             # Create initial step
             step = Step(
                 text=text,
-                reasoning=reasoning if reasoning else None,
+                reasoning_parts=reasoning_parts if reasoning_parts else None,
                 tool_calls=tool_calls if tool_calls else None,
                 finish_reason=act_response.finish_reason,
                 usage=act_response.usage,

--- a/src/scrapybara/client.py
+++ b/src/scrapybara/client.py
@@ -1166,15 +1166,13 @@ class Scrapybara:
             request_options=request_options,
         ):
             steps.append(step)
-            content_parts = []
-            if step.text:
-                content_parts.append(TextPart(text=step.text))
-            if step.reasoning:
-                content_parts.append(ReasoningPart(reasoning=step.reasoning))
-            if step.tool_calls:
-                content_parts.extend(step.tool_calls)
-                
-            assistant_msg = AssistantMessage(content=content_parts)
+            assistant_msg = AssistantMessage(
+                content=(
+                    ([TextPart(text=step.text)] if step.text else [])
+                    + ([ReasoningPart(reasoning=step.reasoning)] if step.reasoning else [])
+                    + (step.tool_calls or [])
+                )
+            )
             result_messages.append(assistant_msg)
             if step.tool_results:
                 tool_msg = ToolMessage(content=step.tool_results)
@@ -1577,15 +1575,13 @@ class AsyncScrapybara:
             request_options=request_options,
         ):
             steps.append(step)
-            content_parts = []
-            if step.text:
-                content_parts.append(TextPart(text=step.text))
-            if step.reasoning:
-                content_parts.append(ReasoningPart(reasoning=step.reasoning))
-            if step.tool_calls:
-                content_parts.extend(step.tool_calls)
-                
-            assistant_msg = AssistantMessage(content=content_parts)
+            assistant_msg = AssistantMessage(
+                content=(
+                    ([TextPart(text=step.text)] if step.text else [])
+                    + ([ReasoningPart(reasoning=step.reasoning)] if step.reasoning else [])
+                    + (step.tool_calls or [])
+                )
+            )
             result_messages.append(assistant_msg)
             if step.tool_results:
                 tool_msg = ToolMessage(content=step.tool_results)

--- a/src/scrapybara/client.py
+++ b/src/scrapybara/client.py
@@ -56,6 +56,7 @@ from .types.act import (
     ToolCallPart,
     ToolMessage,
     ToolResultPart,
+    ReasoningPart,
     UserMessage,
     AssistantMessage,
     Step,
@@ -1306,9 +1307,17 @@ class Scrapybara:
                 if isinstance(part, ToolCallPart)
             ]
 
+            # Extract reasoning from reasoning part
+            reasoning = "\n".join(
+                part.reasoning
+                for part in act_response.message.content
+                if isinstance(part, ReasoningPart)
+            )
+
             # Create initial step
             step = Step(
                 text=text,
+                reasoning=reasoning,
                 tool_calls=tool_calls if tool_calls else None,
                 finish_reason=act_response.finish_reason,
                 usage=act_response.usage,
@@ -1706,9 +1715,17 @@ class AsyncScrapybara:
                 if isinstance(part, ToolCallPart)
             ]
 
+            # Extract reasoning from reasoning part
+            reasoning = "\n".join(
+                part.reasoning
+                for part in act_response.message.content
+                if isinstance(part, ReasoningPart)
+            )
+
             # Create initial step
             step = Step(
                 text=text,
+                reasoning=reasoning,
                 tool_calls=tool_calls if tool_calls else None,
                 finish_reason=act_response.finish_reason,
                 usage=act_response.usage,

--- a/src/scrapybara/client.py
+++ b/src/scrapybara/client.py
@@ -1317,7 +1317,7 @@ class Scrapybara:
             # Create initial step
             step = Step(
                 text=text,
-                reasoning=reasoning,
+                reasoning=reasoning if reasoning else None,
                 tool_calls=tool_calls if tool_calls else None,
                 finish_reason=act_response.finish_reason,
                 usage=act_response.usage,
@@ -1725,7 +1725,7 @@ class AsyncScrapybara:
             # Create initial step
             step = Step(
                 text=text,
-                reasoning=reasoning,
+                reasoning=reasoning if reasoning else None,
                 tool_calls=tool_calls if tool_calls else None,
                 finish_reason=act_response.finish_reason,
                 usage=act_response.usage,

--- a/src/scrapybara/client.py
+++ b/src/scrapybara/client.py
@@ -1169,7 +1169,7 @@ class Scrapybara:
             assistant_msg = AssistantMessage(
                 content=(
                     ([TextPart(text=step.text)] if step.text else [])
-                    + ([ReasoningPart(reasoning=step.reasoning)] if step.reasoning else [])
+                    + (step.reasoning if step.reasoning else [])
                     + (step.tool_calls or [])
                 )
             )
@@ -1309,11 +1309,11 @@ class Scrapybara:
             ]
 
             # Extract reasoning from reasoning part
-            reasoning = "\n".join(
-                part.reasoning
+            reasoning = [
+                part
                 for part in act_response.message.content
                 if isinstance(part, ReasoningPart)
-            )
+            ]
 
             # Create initial step
             step = Step(
@@ -1578,7 +1578,7 @@ class AsyncScrapybara:
             assistant_msg = AssistantMessage(
                 content=(
                     ([TextPart(text=step.text)] if step.text else [])
-                    + ([ReasoningPart(reasoning=step.reasoning)] if step.reasoning else [])
+                    + (step.reasoning if step.reasoning else [])
                     + (step.tool_calls or [])
                 )
             )
@@ -1718,11 +1718,11 @@ class AsyncScrapybara:
             ]
 
             # Extract reasoning from reasoning part
-            reasoning = "\n".join(
-                part.reasoning
+            reasoning = [
+                part
                 for part in act_response.message.content
                 if isinstance(part, ReasoningPart)
-            )
+            ]
 
             # Create initial step
             step = Step(

--- a/src/scrapybara/client.py
+++ b/src/scrapybara/client.py
@@ -1166,12 +1166,15 @@ class Scrapybara:
             request_options=request_options,
         ):
             steps.append(step)
-            assistant_msg = AssistantMessage(
-                content=(
-                    ([TextPart(text=step.text)] if step.text else [])
-                    + (step.tool_calls or [])
-                )
-            )
+            content_parts = []
+            if step.text:
+                content_parts.append(TextPart(text=step.text))
+            if step.reasoning:
+                content_parts.append(ReasoningPart(reasoning=step.reasoning))
+            if step.tool_calls:
+                content_parts.extend(step.tool_calls)
+                
+            assistant_msg = AssistantMessage(content=content_parts)
             result_messages.append(assistant_msg)
             if step.tool_results:
                 tool_msg = ToolMessage(content=step.tool_results)
@@ -1574,12 +1577,15 @@ class AsyncScrapybara:
             request_options=request_options,
         ):
             steps.append(step)
-            assistant_msg = AssistantMessage(
-                content=(
-                    ([TextPart(text=step.text)] if step.text else [])
-                    + (step.tool_calls or [])
-                )
-            )
+            content_parts = []
+            if step.text:
+                content_parts.append(TextPart(text=step.text))
+            if step.reasoning:
+                content_parts.append(ReasoningPart(reasoning=step.reasoning))
+            if step.tool_calls:
+                content_parts.extend(step.tool_calls)
+                
+            assistant_msg = AssistantMessage(content=content_parts)
             result_messages.append(assistant_msg)
             if step.tool_results:
                 tool_msg = ToolMessage(content=step.tool_results)

--- a/src/scrapybara/core/client_wrapper.py
+++ b/src/scrapybara/core/client_wrapper.py
@@ -16,7 +16,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "scrapybara",
-            "X-Fern-SDK-Version": "2.2.8",
+            "X-Fern-SDK-Version": "2.2.9",
         }
         headers["x-api-key"] = self.api_key
         return headers

--- a/src/scrapybara/types/act.py
+++ b/src/scrapybara/types/act.py
@@ -88,7 +88,7 @@ class SingleActResponse(BaseModel):
 # Step definition
 class Step(BaseModel):
     text: str
-    reasoning: Optional[List[ReasoningPart]] = None
+    reasoning_parts: Optional[List[ReasoningPart]] = None
     tool_calls: Optional[List[ToolCallPart]] = None
     tool_results: Optional[List[ToolResultPart]] = None
     finish_reason: Optional[

--- a/src/scrapybara/types/act.py
+++ b/src/scrapybara/types/act.py
@@ -31,6 +31,11 @@ class ToolResultPart(BaseModel):
     result: Any
     is_error: Optional[bool] = False
 
+class ReasoningPart(BaseModel):
+    type: Literal["reasoning"] = "reasoning"
+    reasoning: str
+    signature: Optional[str] = None
+    instructions: Optional[str] = None
 
 class UserMessage(BaseModel):
     role: Literal["user"] = "user"
@@ -39,7 +44,7 @@ class UserMessage(BaseModel):
 
 class AssistantMessage(BaseModel):
     role: Literal["assistant"] = "assistant"
-    content: List[Union[TextPart, ToolCallPart]]
+    content: List[Union[TextPart, ToolCallPart, ReasoningPart]]
 
 
 class ToolMessage(BaseModel):
@@ -83,6 +88,7 @@ class SingleActResponse(BaseModel):
 # Step definition
 class Step(BaseModel):
     text: str
+    reasoning: Optional[str] = None
     tool_calls: Optional[List[ToolCallPart]] = None
     tool_results: Optional[List[ToolResultPart]] = None
     finish_reason: Optional[

--- a/src/scrapybara/types/act.py
+++ b/src/scrapybara/types/act.py
@@ -88,7 +88,7 @@ class SingleActResponse(BaseModel):
 # Step definition
 class Step(BaseModel):
     text: str
-    reasoning: Optional[str] = None
+    reasoning: Optional[List[ReasoningPart]] = None
     tool_calls: Optional[List[ToolCallPart]] = None
     tool_results: Optional[List[ToolResultPart]] = None
     finish_reason: Optional[

--- a/tests/custom/test_client.py
+++ b/tests/custom/test_client.py
@@ -110,8 +110,71 @@ def test_windows() -> None:
     assert response.output.combined_valuation is not None
     windows_instance.stop()
 
+def test_ubuntu_thinking() -> None:
+    _check_api_key()
+    client = Scrapybara()
+
+    ubuntu_instance = client.start_ubuntu()
+    print(ubuntu_instance.get_stream_url().stream_url)
+    assert ubuntu_instance.id is not None
+    instances = client.get_instances()
+    assert len(instances) > 0
+    screenshot_response = ubuntu_instance.screenshot()
+    assert screenshot_response.base_64_image is not None
+    ubuntu_instance.browser.start()
+    cdp_url = ubuntu_instance.browser.get_cdp_url()
+    assert cdp_url is not None
+    response = client.act(
+        model=Anthropic(name="claude-3-7-sonnet-20250219-thinking"),
+        system=UBUNTU_SYSTEM_PROMPT,
+        prompt="Go to the YC website and get the number of funded startups and combined valuation",
+        tools=[
+            ComputerTool(ubuntu_instance),
+            BashTool(ubuntu_instance),
+            EditTool(ubuntu_instance),
+        ],
+        schema=YCStats,
+        on_step=lambda step: print(step.text, step.tool_calls, step.reasoning_parts),
+    )
+    print(response.output)
+    assert response.output is not None
+    assert response.output.number_of_startups is not None
+    assert response.output.combined_valuation is not None
+    ubuntu_instance.browser.stop()
+    ubuntu_instance.stop()
+
+
+def test_browser_thinking() -> None:
+    _check_api_key()
+    client = Scrapybara()
+
+    browser_instance = client.start_browser()
+    print(browser_instance.get_stream_url().stream_url)
+    assert browser_instance.id is not None
+    screenshot_response = browser_instance.screenshot()
+    assert screenshot_response.base_64_image is not None
+    cdp_url = browser_instance.get_cdp_url()
+    assert cdp_url is not None
+    response = client.act(
+        model=Anthropic(name="claude-3-7-sonnet-20250219-thinking"),
+        system=BROWSER_SYSTEM_PROMPT,
+        prompt="Go to the YC website and get the number of funded startups and combined valuation",
+        tools=[
+            ComputerTool(browser_instance),
+        ],
+        schema=YCStats,
+        on_step=lambda step: print(step.text, step.tool_calls, step.reasoning_parts),
+    )
+    print(response.output)
+    assert response.output is not None
+    assert response.output.number_of_startups is not None
+    assert response.output.combined_valuation is not None
+    browser_instance.stop()
+
 
 if __name__ == "__main__":
     test_ubuntu()
     test_browser()
+    test_ubuntu_thinking()
+    test_browser_thinking()
     # test_windows()

--- a/tests/custom/test_client.py
+++ b/tests/custom/test_client.py
@@ -104,7 +104,7 @@ def test_windows() -> None:
         schema=YCStats,
         on_step=lambda step: print(step.text, step.tool_calls),
     )
-    print(response)
+    print(response.output)
     assert response.output is not None
     assert response.output.number_of_startups is not None
     assert response.output.combined_valuation is not None

--- a/tests/custom/test_client.py
+++ b/tests/custom/test_client.py
@@ -48,7 +48,7 @@ def test_ubuntu() -> None:
         schema=YCStats,
         on_step=lambda step: print(step.text, step.tool_calls),
     )
-    print(response)
+    print(response.output)
     assert response.output is not None
     assert response.output.number_of_startups is not None
     assert response.output.combined_valuation is not None
@@ -77,7 +77,7 @@ def test_browser() -> None:
         schema=YCStats,
         on_step=lambda step: print(step.text, step.tool_calls),
     )
-    print(response)
+    print(response.output)
     assert response.output is not None
     assert response.output.number_of_startups is not None
     assert response.output.combined_valuation is not None


### PR DESCRIPTION
Added new `ReasoningPart` type to handle thinking blocks from models such as claude 3.7

Added `ReasoningPart` to `AssistantMessage`

Modified `Step` to include text from `ReasoningPart`

Modified `act_stream()` in `Scrapybara` and `AsyncScrapybara` to include reasoning text in `Step`